### PR TITLE
feat(variables): take consideration of nested variables

### DIFF
--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -80,15 +80,29 @@ export default class Utils {
 
   public static getNestedVariables(fields: Fields) {
     let variables = {};
-    fields?.forEach((field: string | object | NestedField) => {
-      if (isNestedField(field)) {
-        variables = {
-          ...field.variables,
-          ...variables,
-          ...(field.fields && Utils.getNestedVariables(field.fields)),
-        };
-      }
-    });
+
+    function getDeepestVariables(innerFields: Fields) {
+      innerFields?.forEach((field: string | object | NestedField) => {
+        if (isNestedField(field)) {
+          variables = {
+            ...field.variables,
+            ...variables,
+            ...(field.fields && getDeepestVariables(field.fields)),
+          };
+        } else {
+          if (typeof field === "object") {
+            for (const [, value] of Object.entries(field)) {
+              getDeepestVariables(value);
+            }
+          }
+        }
+      });
+
+      return variables;
+    }
+
+    getDeepestVariables(fields);
+
     return variables;
   }
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -204,7 +204,26 @@ describe("Query", () => {
                             type: "Int",
                           },
                         },
-                        fields: ["id", "label"],
+                        fields: [
+                          "id",
+                          "label",
+                          {
+                            operation: "users",
+                            variables: {
+                              userLimit: {
+                                name: "limit",
+                                value: 999,
+                                type: "Int",
+                              },
+                              userFilter: {
+                                name: "filters",
+                                value: "doe",
+                                type: "String",
+                              },
+                            },
+                            fields: ["id", "name"],
+                          },
+                        ],
                       },
                     ],
                   },
@@ -224,8 +243,9 @@ describe("Query", () => {
         ],
       },
     ]);
+
     expect(query).toEqual({
-      query: `query ($id: ID, $visible: Boolean, $platformLimit: Int, $idChannel: Int!, $channelLimit: Int, $rightsLimit: Int, $rightsOffset: Int) { getPublicationNames  { publication (id: $id) { id, name, platforms (visible: $visible, limit: $platformLimit) { totalCount, edges { label, code, parentId, id, rights (idChannel: $idChannel, limit: $rightsLimit, offset: $rightsOffset) { id, label } }, subField, channels (id: $idChannel, limit: $channelLimit) { id, label } } } } }`,
+      query: `query ($id: ID, $visible: Boolean, $platformLimit: Int, $idChannel: Int!, $channelLimit: Int, $rightsLimit: Int, $rightsOffset: Int, $userLimit: Int, $userFilter: String) { getPublicationNames  { publication (id: $id) { id, name, platforms (visible: $visible, limit: $platformLimit) { totalCount, edges { label, code, parentId, id, rights (idChannel: $idChannel, limit: $rightsLimit, offset: $rightsOffset) { id, label, users (limit: $userLimit, filters: $userFilter) { id, name } } }, subField, channels (id: $idChannel, limit: $channelLimit) { id, label } } } } }`,
       variables: {
         id: 12,
         visible: true,
@@ -234,6 +254,8 @@ describe("Query", () => {
         channelLimit: 999,
         rightsLimit: 999,
         rightsOffset: 0,
+        userLimit: 999,
+        userFilter: "doe",
       },
     });
   });

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -164,6 +164,80 @@ describe("Query", () => {
     });
   });
 
+  test("generates query with nested variables in nested fields", () => {
+    const query = queryBuilder.query([
+      {
+        operation: "getPublicationNames",
+        fields: [
+          {
+            operation: "publication",
+            variables: { id: { value: 12, type: "ID" } },
+            fields: [
+              "id",
+              "name",
+              {
+                operation: "platforms",
+                variables: {
+                  visible: { type: "Boolean", value: true },
+                  platformLimit: { name: "limit", value: 999, type: "Int" },
+                },
+                fields: [
+                  "totalCount",
+                  {
+                    edges: [
+                      "label",
+                      "code",
+                      "parentId",
+                      "id",
+                      {
+                        operation: "rights",
+                        variables: {
+                          idChannel: { type: "Int", required: true },
+                          rightsLimit: {
+                            name: "limit",
+                            value: 999,
+                            type: "Int",
+                          },
+                          rightsOffset: {
+                            name: "offset",
+                            value: 0,
+                            type: "Int",
+                          },
+                        },
+                        fields: ["id", "label"],
+                      },
+                    ],
+                  },
+                  "subField",
+                  {
+                    operation: "channels",
+                    variables: {
+                      idChannel: { name: "id", type: "Int", required: true },
+                      channelLimit: { name: "limit", value: 999, type: "Int" },
+                    },
+                    fields: ["id", "label"],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    ]);
+    expect(query).toEqual({
+      query: `query ($id: ID, $visible: Boolean, $platformLimit: Int, $idChannel: Int!, $channelLimit: Int, $rightsLimit: Int, $rightsOffset: Int) { getPublicationNames  { publication (id: $id) { id, name, platforms (visible: $visible, limit: $platformLimit) { totalCount, edges { label, code, parentId, id, rights (idChannel: $idChannel, limit: $rightsLimit, offset: $rightsOffset) { id, label } }, subField, channels (id: $idChannel, limit: $channelLimit) { id, label } } } } }`,
+      variables: {
+        id: 12,
+        visible: true,
+        platformLimit: 999,
+        idChannel: undefined,
+        channelLimit: 999,
+        rightsLimit: 999,
+        rightsOffset: 0,
+      },
+    });
+  });
+
   test("generates query with object variables nested in fields", () => {
     const query = queryBuilder.query([
       {


### PR DESCRIPTION
Hello community!

Nested fields have served me well. Nevertheless, the variables for the sub-operations were not added to the variables of the query (only the first sub-operation).

So I propose a small modification to collect all the variables, no matter how deep they are.

Below, the result of the query added in test.

```graphql
query(
  $id: ID
  $visible: Boolean
  $platformLimit: Int
  $idChannel: Int!
  $channelLimit: Int
  $rightsLimit: Int
  $rightsOffset: Int
  $userLimit: Int
  $userFilter: String
) {
  getPublicationNames {
    publication(id: $id) {
      id
      name
      platforms(visible: $visible, limit: $platformLimit) {
        totalCount
        edges {
          label
          code
          parentId
          id
          rights(
            idChannel: $idChannel
            limit: $rightsLimit
            offset: $rightsOffset
          ) {
            id
            label
            users(limit: $userLimit, filters: $userFilter) {
              id
              name
            }
          }
        }
        subField
        channels(id: $idChannel, limit: $channelLimit) {
          id
          label
        }
      }
    }
  }
}

```



thanks to all of you :) 